### PR TITLE
Release v1.1.0: Add support for the `droplet_provisioner_external_ip` variable for the remote provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/terraform-setup-environment/compare/v1.0.1...v1.1.0 by @obervinov
 #### 🚀 Features
-* add support `external_ip` variable for remote provisioner
+* add support for the droplet_provisioner_external_ip variable for the remote provider
 
 
 ## v1.0.1 - 2025-01-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## v1.1.0 - 2025-01-13
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/terraform-setup-environment/compare/v1.0.1...v1.1.0 by @obervinov
+#### 🚀 Features
+* add support `external_ip` variable for remote provisioner
+
 
 ## v1.0.1 - 2025-01-12
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ No modules.
 | <a name="input_droplet_image"></a> [droplet\_image](#input\_droplet\_image) | The image of the droplet (must be available in the region). Default: ubuntu-1vcpu-512mb.rev1 | `string` | `"ubuntu-1vcpu-512mb.rev1"` | no |
 | <a name="input_droplet_name"></a> [droplet\_name](#input\_droplet\_name) | The name of the droplet (must be unique) | `string` | n/a | yes |
 | <a name="input_droplet_project"></a> [droplet\_project](#input\_droplet\_project) | The target project for the droplet | `string` | n/a | yes |
+| <a name="input_droplet_provisioner_external_ip"></a> [droplet\_provisioner\_external\_ip](#input\_droplet\_provisioner\_external\_ip) | External IP for provisioner connection to droplet | `bool` | `false` | no |
 | <a name="input_droplet_provisioner_ssh_key"></a> [droplet\_provisioner\_ssh\_key](#input\_droplet\_provisioner\_ssh\_key) | Private key for provisioner connection to droplet (must be base64 encoded) | `string` | n/a | yes |
 | <a name="input_droplet_region"></a> [droplet\_region](#input\_droplet\_region) | The region of the droplet (must be available) | `string` | `"ams3"` | no |
 | <a name="input_droplet_reserved_ip"></a> [droplet\_reserved\_ip](#input\_droplet\_reserved\_ip) | Link a reserved address to a droplet | `bool` | `false` | no |

--- a/data.tf
+++ b/data.tf
@@ -1,21 +1,19 @@
 locals {
+  remote_provisioner_host = var.droplet_provisioner_external_ip ? digitalocean_droplet.this.ipv4_address : digitalocean_droplet.this.ipv4_address_private
   default_environment_variables = [
     "DROPLET_INTERNAL_IP=${digitalocean_droplet.this.ipv4_address_private}",
     "DROPLET_EXTERNAL_IP=${digitalocean_droplet.this.ipv4_address}",
   ]
-
   default_packages = [
     "curl",
     "mc",
     "net-tools"
   ]
-
   default_commands = [
     "sudo mkdir -p ${var.app_data}/${var.app_configurations}",
     "sudo chown ${var.droplet_user}:terraform ${var.app_data}/${var.app_configurations}",
     "sudo chmod 775 ${var.app_data}/${var.app_configurations}",
   ]
-
   user_data = <<EOF
 #cloud-config
 

--- a/environment.tf
+++ b/environment.tf
@@ -6,7 +6,7 @@ resource "null_resource" "cloudinit" {
   triggers = { droplet = digitalocean_droplet.this.id }
 
   connection {
-    host        = digitalocean_droplet.this.ipv4_address_private
+    host        = local.remote_provisioner_host
     user        = "terraform"
     type        = "ssh"
     agent       = false
@@ -33,7 +33,7 @@ resource "null_resource" "etc_hosts" {
   }
 
   connection {
-    host        = digitalocean_droplet.this.ipv4_address_private
+    host        = local.remote_provisioner_host
     user        = "terraform"
     type        = "ssh"
     agent       = false
@@ -59,7 +59,7 @@ resource "null_resource" "swap" {
   }
 
   connection {
-    host        = digitalocean_droplet.this.ipv4_address_private
+    host        = local.remote_provisioner_host
     user        = "terraform"
     type        = "ssh"
     agent       = false
@@ -90,7 +90,7 @@ resource "null_resource" "environment_variables" {
   }
 
   connection {
-    host        = digitalocean_droplet.this.ipv4_address_private
+    host        = local.remote_provisioner_host
     user        = "terraform"
     type        = "ssh"
     agent       = false
@@ -117,7 +117,7 @@ resource "null_resource" "files" {
   }
 
   connection {
-    host        = digitalocean_droplet.this.ipv4_address_private
+    host        = local.remote_provisioner_host
     user        = "terraform"
     type        = "ssh"
     agent       = false
@@ -147,7 +147,7 @@ resource "null_resource" "additional_commands" {
   }
 
   connection {
-    host        = digitalocean_droplet.this.ipv4_address_private
+    host        = local.remote_provisioner_host
     user        = "terraform"
     type        = "ssh"
     agent       = false
@@ -167,7 +167,7 @@ resource "null_resource" "volume_mount" {
   triggers = { droplet = digitalocean_droplet.this.id }
 
   connection {
-    host        = digitalocean_droplet.this.ipv4_address_private
+    host        = local.remote_provisioner_host
     user        = "terraform"
     type        = "ssh"
     agent       = false

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "droplet_provisioner_ssh_key" {
   type        = string
 }
 
+variable "droplet_provisioner_external_ip" {
+  description = "External IP for provisioner connection to droplet"
+  type        = bool
+  default     = false
+}
+
 variable "droplet_do_agent" {
   description = "Enable DigitalOcean agent for droplet (for monitoring and backups)"
   type        = bool


### PR DESCRIPTION
## v1.1.0 - 2025-01-13
### What's Changed
**Full Changelog**: https://github.com/obervinov/terraform-setup-environment/compare/v1.0.1...v1.1.0 by @obervinov
#### 🚀 Features
* add support for the droplet_provisioner_external_ip variable for the remote provider


