### PR TITLE
Fix v2.0.1: Fix `dns_record` output 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v2.0.1 - 2025-06-24
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/terraform-setup-environment/compare/v2.0.0...v2.0.1 by @obervinov
+#### 🐛 Bug Fixes
+* fix `dns_record` output for the Cloudflare DNS provider
+
+
 ## v2.0.0 - 2025-06-24
 ### What's Changed
 **Full Changelog**: https://github.com/obervinov/terraform-setup-environment/compare/v1.1.0...v2.0.0 by @obervinov

--- a/output.tf
+++ b/output.tf
@@ -28,10 +28,13 @@ output "droplet_dns" {
   value = {
     # Determines whether to include DNS record information in the output. This condition
     # typically depends on whether DNS records are configured for the droplet.
-    dns_record = local.dns_record_condition ? try(digitalocean_record.this[0].fqdn, "") : ""
+    dns_record = (
+      var.droplet_dns_record && var.dns_provider == "digitalocean" ?
+      try(digitalocean_record.this[0].fqdn, "") :
+      ""
+    )
     cname_records = (
       length(var.app_cname_records) > 0 &&
-      local.dns_record_condition &&
       length(data.digitalocean_domain.this) > 0
     ) ? join(", ", [for item in var.app_cname_records : "${item}.${data.digitalocean_domain.this[0].name}"]) : ""
   }


### PR DESCRIPTION
## v2.0.1 - 2025-06-24
### What's Changed
**Full Changelog**: https://github.com/obervinov/terraform-setup-environment/compare/v2.0.0...v2.0.1 by @obervinov
#### 🐛 Bug Fixes
* fix `dns_record` output for the Cloudflare DNS provider


